### PR TITLE
Find autoload

### DIFF
--- a/php/getfilepath.php
+++ b/php/getfilepath.php
@@ -5,9 +5,14 @@ $rootpath = $argv[3];
 
 require __DIR__ . '/FQCN.php';
 
+$foundAutoLoader = false;
+
 // First try default location
-if(getFilePath($rootpath . '/vendor/autoload.php', $class, $file)) {
-  exit(0);
+if(is_readable($autoloader)) {
+  $foundAutoLoader = true;
+  if(getFilePath($rootpath . '/vendor/autoload.php', $class, $file)) {
+    exit(0);
+  }
 }
 
 // Try to find autoloader.php elsewhere in $rootpath
@@ -15,12 +20,17 @@ $dirIterator = new RecursiveDirectoryIterator($rootpath);
 $reqIterator = new RecursiveIteratorIterator($dirIterator);
 $regexIterator = new RegexIterator($reqIterator, '#/vendor/autoload.php$#i');
 foreach($regexIterator as $autoloader) {
+  $foundAutoLoader = true;
   if(getFilePath($autoloader, $class, $file)) {
     exit(0);
   }
 }
 
-echo "Class $class not found, please make sure the composer vendor/autoload.php file exists in your project and is readable.";
+if($foundAutoLoader) {
+  echo "Class $class not found.";
+} else {
+  echo "Class $class not found, please make sure the composer vendor/autoload.php file exists in your project and is readable.";
+}
 
 function getFilePath($autoloader, $class, $file) {
   if (!is_readable($autoloader)) {

--- a/php/getfilepath.php
+++ b/php/getfilepath.php
@@ -2,26 +2,57 @@
 $class = $argv[1];
 $file = $argv[2];
 $rootpath = $argv[3];
-$autoloader = $rootpath . '/vendor/autoload.php';
-if (is_readable($autoloader)) {
-    $loader = require $autoloader;
 
-    require __DIR__ . '/FQCN.php';
+require __DIR__ . '/FQCN.php';
 
-    $contents = file_get_contents($file);
-    $fqns = new Hkt\FQCN();
-    $useClasses = $fqns->getAllUseStatements($contents);
-    if (array_key_exists($class, $useClasses)) {
-        echo $loader->findFile($useClasses[$class]);
-    } else {
-        // Get current namespace
-        $namespace = $fqns->getNamespace();
-        if ($namespace) {
-            $class = $namespace . '\\' . $class;
-        }
-        echo $loader->findFile($class);
-    }
+// First try default location
+if(getFilePath($rootpath . '/vendor/autoload.php', $class, $file)) {
+  exit(0);
+}
 
-} else {
-    echo "Please make sure the composer vendor/autoload.php file exists in root of project and is readable.";
+// Try to find autoloader.php elsewhere in $rootpath
+$dirIterator = new RecursiveDirectoryIterator($rootpath);
+$reqIterator = new RecursiveIteratorIterator($dirIterator);
+$regexIterator = new RegexIterator($reqIterator, '#/vendor/autoload.php$#i');
+foreach($regexIterator as $autoloader) {
+  if(getFilePath($autoloader, $class, $file)) {
+    exit(0);
+  }
+}
+
+echo "Class $class not found, please make sure the composer vendor/autoload.php file exists in your project and is readable.";
+
+function getFilePath($autoloader, $class, $file) {
+  if (!is_readable($autoloader)) {
+    return false;
+  }
+
+  $loader = require $autoloader;
+
+  $contents = file_get_contents($file);
+  $fqns = new Hkt\FQCN();
+  $useClasses = $fqns->getAllUseStatements($contents);
+  if (array_key_exists($class, $useClasses)) {
+      echo $loader->findFile($useClasses[$class]);
+      return true;
+  }
+
+  // Try using current namespace
+  $namespace = $fqns->getNamespace();
+  if ($namespace) {
+      $foundFile = $loader->findFile($namespace . '\\' . $class);
+      if($foundFile) {
+        echo $foundFile;
+        return true;
+      }
+  }
+
+  // Try using global namespace
+  $foundFile = $loader->findFile($class);
+  if($foundFile) {
+    echo $foundFile;
+    return true;
+  }
+
+  return false;
 }

--- a/php/getfilepath.php
+++ b/php/getfilepath.php
@@ -8,6 +8,7 @@ require __DIR__ . '/FQCN.php';
 $foundAutoLoader = false;
 
 // First try default location
+$autoloader = $rootpath . '/vendor/autoload.php';
 if(is_readable($autoloader)) {
   $foundAutoLoader = true;
   if(getFilePath($rootpath . '/vendor/autoload.php', $class, $file)) {
@@ -15,7 +16,7 @@ if(is_readable($autoloader)) {
   }
 }
 
-// Try to find autoloader.php elsewhere in $rootpath
+// Try to find autoload.php elsewhere in $rootpath
 $dirIterator = new RecursiveDirectoryIterator($rootpath);
 $reqIterator = new RecursiveIteratorIterator($dirIterator);
 $regexIterator = new RegexIterator($reqIterator, '#/vendor/autoload.php$#i');


### PR DESCRIPTION
My `vendor/autoload.php` is not in the root of my project (as the project contains other stuff besides the source code).

The improved script is able to find any `vendor/autoload.php` in the project, if it is not found in the root of the project.

Additionally, changed the error message when the autoloader has been found (but the class is not), making it less obnoxious.
